### PR TITLE
Apuntando los links relativos al hosting estático

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" href="https://raw.github.com/daneden/animate.css/master/animate.css">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
 	<link href="https://fonts.googleapis.com/css2?family=Oswald:wght@500&family=Roboto&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/estilos.css">
+	<link rel="stylesheet" href="/tatomarietti/css/estilos.css">
 	<meta name="description" content="MTH CarDetail - Correcion de pintura - Tratamientos de proteccion - 
 	Limpieza de interiro - Capacitaciones">
 	<meta name="keywords" content="detail, detailing, tratamientos ceramicos, limpieza de interiro, correcin de pintura, curso de detail, cordoba">

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" href="https://raw.github.com/daneden/animate.css/master/animate.css">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
 	<link href="https://fonts.googleapis.com/css2?family=Oswald:wght@500&family=Roboto&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="/tatomarietti/css/estilos.css">
+	<link rel="stylesheet" href="CSS/estilos.css">
 	<meta name="description" content="MTH CarDetail - Correcion de pintura - Tratamientos de proteccion - 
 	Limpieza de interiro - Capacitaciones">
 	<meta name="keywords" content="detail, detailing, tratamientos ceramicos, limpieza de interiro, correcin de pintura, curso de detail, cordoba">
@@ -18,7 +18,7 @@
 		<!-- Encabezado logo y menu -->
 		
 		<div class="header__logomth">
-			<a href="index.html"> <img src="imagenes/logo mth.png" alt="logotipo MTH"> </a>  
+			<a href="index.html"> <img src="Imagenes/logo mth.png" alt="logotipo MTH"> </a>  
 		</div>
 
 

--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
 	<link rel="stylesheet" href="https://raw.github.com/daneden/animate.css/master/animate.css">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
 	<link href="https://fonts.googleapis.com/css2?family=Oswald:wght@500&family=Roboto&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="CSS/estilos.css">
+	<link rel="stylesheet" href="http://mthcardetail.000webhostapp.com/CSS/estilos.css">
 	<meta name="description" content="MTH CarDetail - Correcion de pintura - Tratamientos de proteccion - 
 	Limpieza de interiro - Capacitaciones">
 	<meta name="keywords" content="detail, detailing, tratamientos ceramicos, limpieza de interiro, correcin de pintura, curso de detail, cordoba">
 	<title> MTH Car Detail - Etetica vehicular</title>
-	<link rel="shortcut icon" type="image/x-icon" href="Imagenes/logomth.png">
+	<link rel="shortcut icon" type="image/x-icon" href="http://mthcardetail.000webhostapp.com/Imagenes/logomth.png">
 </head>
 
 <body>
@@ -18,7 +18,7 @@
 		<!-- Encabezado logo y menu -->
 		
 		<div class="header__logomth">
-			<a href="index.html"> <img src="Imagenes/logo mth.png" alt="logotipo MTH"> </a>  
+			<a href="index.html"> <img src="http://mthcardetail.000webhostapp.com/Imagenes/logo%20mth.png" alt="logotipo MTH"> </a>  
 		</div>
 
 


### PR DESCRIPTION
Github pages no se lleva bien con los links relativos, por eso cambiando a links absolutos apuntando al root del hosting estático en 000webhostapp.com, el navegador los puede resolver.

También había dos errores de mayúsculas/minúsculas en los nombres de las carpetas, la mayoría de los sistemas de archivos no windows tienen en cuenta las mayúsculas y minúsculas en los paths y nombres de archivos, por eso hay que cambiar de 
**_css_** a **_CSS_** en el link de estilos y poner la i mayúscula en el link del logo. 

Tampoco es buena idea dejar espacios en los nombres de archivos y carpetas, en la línea 21 los caracteres **_%20_** representan un espacio en codificación de urls.